### PR TITLE
Fix export_data.py to include all 87 playerstats fields in player_gam…

### DIFF
--- a/scripts/export_data.py
+++ b/scripts/export_data.py
@@ -33,13 +33,25 @@ CUMULATIVE_COLS = [
     'yellow_cards', 'red_cards', 'saves', 'starts', 'bonus', 'bps',
     'transfers_in', 'transfers_out', 'dreamteam_count', 'expected_goals',
     'expected_assists', 'expected_goal_involvements', 'expected_goals_conceded',
-    'influence', 'creativity', 'threat', 'ict_index'
+    'influence', 'creativity', 'threat', 'ict_index', 'tackles',
+    'clearances_blocks_interceptions', 'recoveries', 'defensive_contribution'
 ]
 ID_COLS = ['id', 'first_name', 'second_name', 'web_name']
 SNAPSHOT_COLS = [
-    'status', 'news', 'now_cost', 'selected_by_percent', 'form', 'event_points',
-    'cost_change_event', 'transfers_in_event', 'transfers_out_event',
-    'value_form', 'value_season', 'ep_next', 'ep_this'
+    'status', 'news', 'news_added', 'now_cost', 'now_cost_rank', 'now_cost_rank_type',
+    'selected_by_percent', 'selected_rank', 'selected_rank_type', 'form', 'form_rank',
+    'form_rank_type', 'event_points', 'cost_change_event', 'cost_change_event_fall',
+    'cost_change_start', 'cost_change_start_fall', 'transfers_in_event', 'transfers_out_event',
+    'value_form', 'value_season', 'ep_next', 'ep_this', 'points_per_game',
+    'points_per_game_rank', 'points_per_game_rank_type', 'chance_of_playing_next_round',
+    'chance_of_playing_this_round', 'influence_rank', 'influence_rank_type',
+    'creativity_rank', 'creativity_rank_type', 'threat_rank', 'threat_rank_type',
+    'ict_index_rank', 'ict_index_rank_type', 'corners_and_indirect_freekicks_order',
+    'direct_freekicks_order', 'penalties_order', 'set_piece_threat',
+    'corners_and_indirect_freekicks_text', 'direct_freekicks_text', 'penalties_text',
+    'expected_goals_per_90', 'expected_assists_per_90', 'expected_goal_involvements_per_90',
+    'expected_goals_conceded_per_90', 'saves_per_90', 'clean_sheets_per_90',
+    'goals_conceded_per_90', 'starts_per_90', 'defensive_contribution_per_90', 'gw'
 ]
 
 


### PR DESCRIPTION
…eweek_stats.csv

Previously only 43 fields were exported. Now includes all fields from the database schema:

CUMULATIVE_COLS additions:
- tackles, clearances_blocks_interceptions, recoveries, defensive_contribution

SNAPSHOT_COLS additions:
- All rank fields (*_rank, *_rank_type)
- All per-90 stats (*_per_90)
- Set piece fields (order, text, threat)
- Chance of playing fields
- Additional cost change fields
- news_added, points_per_game, gw

🤖 Generated with [Claude Code](https://claude.com/claude-code)