### PR TITLE
Fix KeyError when merging playerstats with missing columns

### DIFF
--- a/scripts/export_data.py
+++ b/scripts/export_data.py
@@ -129,8 +129,10 @@ def calculate_discrete_gameweek_stats():
                 continue
 
             prev_df = pd.read_csv(prev_stats_path)
-            merged_df = pd.merge(current_df, prev_df[ID_COLS + CUMULATIVE_COLS], on='id', how='left', suffixes=('', '_prev'))
-            
+            # Only use columns that exist in previous dataframe
+            prev_cols_to_merge = [col for col in ID_COLS + CUMULATIVE_COLS if col in prev_df.columns]
+            merged_df = pd.merge(current_df, prev_df[prev_cols_to_merge], on='id', how='left', suffixes=('', '_prev'))
+
             for col in CUMULATIVE_COLS:
                 if col in merged_df.columns and f"{col}_prev" in merged_df.columns:
                     merged_df[f"{col}_prev"] = merged_df[f"{col}_prev"].fillna(0)
@@ -181,8 +183,10 @@ def calculate_discrete_gameweek_stats():
                     continue
                 
                 prev_df = pd.read_csv(prev_stats_path)
-                merged_df = pd.merge(current_df, prev_df[ID_COLS + CUMULATIVE_COLS], on='id', how='left', suffixes=('', '_prev'))
-                
+                # Only use columns that exist in previous dataframe
+                prev_cols_to_merge = [col for col in ID_COLS + CUMULATIVE_COLS if col in prev_df.columns]
+                merged_df = pd.merge(current_df, prev_df[prev_cols_to_merge], on='id', how='left', suffixes=('', '_prev'))
+
                 for col in CUMULATIVE_COLS:
                     if col in merged_df.columns and f"{col}_prev" in merged_df.columns:
                         merged_df[f"{col}_prev"] = merged_df[f"{col}_prev"].fillna(0)


### PR DESCRIPTION
Historical gameweek CSV files don't have newer fields (tackles, clearances_blocks_interceptions, recoveries) that were added to the database later. The script was trying to access these columns without checking if they exist first.

Solution: Filter to only columns that exist in previous dataframe before merging. This allows the script to handle:
- New fields that don't exist in historical data (won't be differenced)
- Existing fields in both current and previous (will be differenced correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)