### PR TITLE
Fix total_points corruption from negative-diff fallback in export_data.py

### DIFF
--- a/scripts/export_data.py
+++ b/scripts/export_data.py
@@ -192,15 +192,25 @@ def calculate_discrete_gameweek_stats():
             prev_cols_to_merge = [col for col in ID_COLS + CUMULATIVE_COLS if col in prev_df.columns]
             merged_df = pd.merge(current_df, prev_df[prev_cols_to_merge], on='id', how='left', suffixes=('', '_prev'))
 
+            # total_points has an exact per-GW value in event_points already —
+            # use it directly instead of diffing the cumulative season total.
+            if 'total_points' in merged_df.columns and 'event_points' in merged_df.columns:
+                merged_df['total_points'] = merged_df['event_points']
+
             for col in CUMULATIVE_COLS:
+                if col == 'total_points':
+                    continue
                 if col in merged_df.columns and f"{col}_prev" in merged_df.columns:
                     merged_df[f"{col}_prev"] = merged_df[f"{col}_prev"].fillna(0)
                     # Calculate the difference
                     diff = merged_df[col] - merged_df[f"{col}_prev"]
-                    # If difference is negative, use current value as-is (data quality issue)
-                    # Otherwise use the calculated difference
-                    merged_df[col] = diff.where(diff >= 0, merged_df[col])
-            
+                    # If difference is negative, treat this GW as no change (0)
+                    # instead of substituting the raw cumulative value, which
+                    # could inject a whole season's total into a single GW row.
+                    # GAP: this also zeroes out real small negative corrections
+                    # instead of preserving them — needs a proper fix.
+                    merged_df[col] = diff.where(diff >= 0, 0)
+
             final_cols = ID_COLS + SNAPSHOT_COLS + CUMULATIVE_COLS
             existing_final_cols = [col for col in final_cols if col in merged_df.columns]
             output_df = merged_df[existing_final_cols]
@@ -250,14 +260,24 @@ def calculate_discrete_gameweek_stats():
                 prev_cols_to_merge = [col for col in ID_COLS + CUMULATIVE_COLS if col in prev_df.columns]
                 merged_df = pd.merge(current_df, prev_df[prev_cols_to_merge], on='id', how='left', suffixes=('', '_prev'))
 
+                # total_points has an exact per-GW value in event_points already —
+                # use it directly instead of diffing the cumulative season total.
+                if 'total_points' in merged_df.columns and 'event_points' in merged_df.columns:
+                    merged_df['total_points'] = merged_df['event_points']
+
                 for col in CUMULATIVE_COLS:
+                    if col == 'total_points':
+                        continue
                     if col in merged_df.columns and f"{col}_prev" in merged_df.columns:
                         merged_df[f"{col}_prev"] = merged_df[f"{col}_prev"].fillna(0)
                         # Calculate the difference
                         diff = merged_df[col] - merged_df[f"{col}_prev"]
-                        # If difference is negative, use current value as-is (data quality issue)
-                        # Otherwise use the calculated difference
-                        merged_df[col] = diff.where(diff >= 0, merged_df[col])
+                        # If difference is negative, treat this GW as no change (0)
+                        # instead of substituting the raw cumulative value, which
+                        # could inject a whole season's total into a single GW row.
+                        # GAP: this also zeroes out real small negative corrections
+                        # instead of preserving them — needs a proper fix.
+                        merged_df[col] = diff.where(diff >= 0, 0)
 
                 final_cols = ID_COLS + SNAPSHOT_COLS + CUMULATIVE_COLS
                 existing_final_cols = [col for col in final_cols if col in merged_df.columns]


### PR DESCRIPTION
## Problem

`calculate_discrete_gameweek_stats()` derives each gameweek's `total_points` by diffing the cumulative season total against the previous gameweek's cumulative total. When a point correction (rescinded bonus, red card, own goal, etc.) makes that diff negative, the existing fallback (introduced in da892cc9) substitutes the raw *current cumulative* value instead of the diff — injecting an entire season's running total into a single gameweek's row.

**Example**: GW33's `player_gameweek_stats.csv` shows Nordi Mukiele with `total_points=128` for that single gameweek, while `event_points=-1` for the same row. The true GW33 delta was -1 (matching `event_points`); the fallback replaced it with his cumulative total through GW33 (128) instead. This isn't isolated — 73 rows across the current season's local data show the same `total_points != event_points` pattern, always with a large positive `total_points` paired with a small negative `event_points`.

This surfaced downstream in a "Top 20 point scorers" chart that summed the corrupted `total_points` column and put a bench player at #1.

## Root cause

```python
diff = merged_df[col] - merged_df[f"{col}_prev"]
# If difference is negative, use current value as-is (data quality issue)
merged_df[col] = diff.where(diff >= 0, merged_df[col])
```

`merged_df[col]` here is still the *current, un-diffed* cumulative snapshot at the point this line runs (current_df keeps its column unsuffixed in the merge). So "use current value as-is" doesn't mean "leave it unchanged" — it substitutes the full season-to-date cumulative into that one row.

The original fix (da892cc9) was guarding against genuine upstream corruption (e.g. a `bps` counter going 146 → 21 in one week, diff = -125), but the fallback doesn't distinguish that from an ordinary small point correction (diff = -1), and "inject the raw cumulative" is arguably worse than the disease in the small-correction case.

## Fix

- `total_points` already has an exact per-GW value sitting in `event_points` (`SNAPSHOT_COLS`, never diffed) — use it directly instead of diffing the cumulative total. No schema change; `total_points` stays as a column with the same name, just computed correctly.
- For the remaining `CUMULATIVE_COLS` (`bps`, `bonus`, `ict_index`, etc.), which don't have an independent per-GW source to fall back on, treat a negative diff as `0` (no measurable change that GW) instead of substituting the raw cumulative. This is a strict improvement in both the corruption case and the correction case — it never fabricates an implausible single-GW value.
- Left a `GAP` comment on that block: zeroing also flattens *real* small negative corrections (which are legitimate and already visible elsewhere in the data via `event_points`) instead of preserving their true value. A magnitude-aware threshold that only zeroes out implausibly large drops would be more accurate, but needs per-stat tuning — flagged as a follow-up rather than guessed at here.

## Note on existing data

This only fixes the pipeline going forward. The ~73 already-affected rows in the current season's exported CSVs would need a re-run of `export_data.py` against Supabase to backfill — I don't have those credentials, so that part is up to a maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)