### PR TITLE
Handle empty playermatchstats and derive the season automatically

### DIFF
--- a/scripts/export_data.py
+++ b/scripts/export_data.py
@@ -6,10 +6,27 @@ import sys
 import pandas as pd
 from supabase import create_client, Client
 import logging
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 
 # --- Configuration ---
-SEASON = "2025-2026"
+
+
+def derive_season(today: date | None = None) -> str:
+    """
+    Current season folder name, e.g. "2026-2027". The season flips on
+    1 July, matching the scraper repo's season derivation. Override with
+    the SEASON env var (e.g. SEASON=2025-2026) to backfill an old season.
+    """
+    override = os.environ.get("SEASON")
+    if override:
+        return override
+    if today is None:
+        today = date.today()
+    start = today.year if today.month >= 7 else today.year - 1
+    return f"{start}-{start + 1}"
+
+
+SEASON = derive_season()
 BASE_DATA_PATH = os.path.join('data', SEASON)
 TOURNAMENT_NAME_MAP = {
     'friendly': 'Friendlies',
@@ -379,6 +396,14 @@ def main():
     if any(df.empty for df in essential_dfs):
         logger.error("❌ Critical: One or more essential tables could not be fetched. Aborting.")
         sys.exit(1)
+
+    # playermatchstats is legitimately empty at the start of a season (no
+    # matches played yet). An empty Supabase result has no columns at all,
+    # which would crash every ['match_id'] lookup below - normalize it to
+    # the canonical column set so filters return empty frames instead.
+    if playermatchstats_df.empty:
+        logger.info("  > 'playermatchstats' is empty (season not started?) - continuing with empty stats.")
+        playermatchstats_df = ensure_playermatchstats_columns(pd.DataFrame())
 
     # --- Data Pre-processing ---
     def extract_tournament_slug(match_id):


### PR DESCRIPTION
Two season-start fixes for `export_data.py`, found running it against the freshly reset 2026-27 database:

- **Empty `playermatchstats` crash**: with no matches played yet, Supabase returns zero rows, which pandas turns into a DataFrame with *no columns* — every `['match_id']` lookup then raised `KeyError` (the failure in the last three runs). The empty result is now normalized to the canonical 64-column set so filters return empty frames and gameweek folders get headers-only CSVs.
- **Hardcoded `SEASON = "2025-2026"`**: the export was about to write fresh 26-27 data into last season's folder. The season is now derived from the date (1-July rollover, same rule as the scraper repo), with a `SEASON` env override for backfills. This run writes to `data/2026-2027/`.

Merging to `main` because `workflow_dispatch` runs kept executing `main`'s old copy of the script regardless of intent — with this on the default branch, running the workflow needs no branch selection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hk8oURDYBGnzeaDtJmka24

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hk8oURDYBGnzeaDtJmka24)_