### PR TITLE
Re-enable twice-daily data refresh (07:30 / 17:30 UTC)

### DIFF
--- a/.github/workflows/update_data.yml
+++ b/.github/workflows/update_data.yml
@@ -1,8 +1,14 @@
 name: Data Import from Supabase
 
 on:
-  # Get ready for 26/27 season
-  workflow_dispatch:
+  schedule:
+    - cron: '30 7 * * *'   # 07:30 UTC - after the Supabase pipeline's overnight runs finish (~07:00)
+    - cron: '30 17 * * *'  # 17:30 UTC - evening refresh
+  workflow_dispatch:  # Manual run always available
+
+concurrency:
+  group: update-data
+  cancel-in-progress: false
 
 jobs:
   export-data:

--- a/README.md
+++ b/README.md
@@ -30,8 +30,9 @@ It’s a simple way to:
 
 ## Data Updates
 
-The dataset is refreshed automatically every day during the season
-(pre-season updates may be less frequent).
+The dataset is automatically refreshed twice daily at:
+- **7:30 AM UTC**
+- **5:30 PM UTC**
 
 All data is provided in **CSV format** for easy import into any data analysis tool.
 


### PR DESCRIPTION
Puts `update_data.yml` back on a twice-daily schedule for 2026/27. The morning run moves from last season's 05:00 to **07:30 UTC** so it exports *after* the upstream Supabase pipeline finishes its overnight work (match/player stats 04:00–04:30, FPL sync 06:00, data health check 07:00) — at 05:00 it would have grabbed yesterday's numbers mid-pipeline. Evening run at **17:30 UTC**, matching last season's cadence. Adds a concurrency group so a manual run can't race a scheduled one on the data commit, and updates the README's stated refresh times to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hk8oURDYBGnzeaDtJmka24

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hk8oURDYBGnzeaDtJmka24)_