### PR TITLE
Run the Supabase data import three times a day

### DIFF
--- a/.github/workflows/update_data.yml
+++ b/.github/workflows/update_data.yml
@@ -2,8 +2,9 @@ name: Data Import from Supabase
 
 on:
   schedule:
-    - cron: '30 7 * * *'   # 07:30 UTC - after the Supabase pipeline's overnight runs finish (~07:00)
-    - cron: '30 17 * * *'  # 17:30 UTC - evening refresh
+    - cron: '30 7 * * *'   # 07:30 UTC - 30 min after the Supabase pipeline's data health check
+    - cron: '30 15 * * *'  # 15:30 UTC - second pass, +8h
+    - cron: '30 23 * * *'  # 23:30 UTC - third pass, +16h
   workflow_dispatch:  # Manual run always available
 
 concurrency:


### PR DESCRIPTION
Replaces the 07:30/17:30 pair with an 8-hour cycle at 07:30, 15:30 and 23:30 UTC.

Each slot lands 30 minutes after the scraper repo's Data Health check, preserving the ordering intent behind the original 07:30 slot. Pairs with olbauday/Football-Scraper-Scripts, which moves its pipeline to the same 8-hour cycle.

Scheduled runs go from 2/day to 3/day.

## Not included

`splitdata.yml` is untouched — it is `workflow_dispatch` only and parked for the 26/27 season.

## Notes

This workflow commits its output back to the repository, so `main` will receive 3 auto-update commits a day instead of 2.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TxQzYouD4hhRCJ49xsJP4T)_